### PR TITLE
Support browserify 10.2.1's sourcemap comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function extract(opts){
             var src = file.contents.toString('utf8');
             var sMapFileName = opts.sourceMappingFileName ? path.basename(opts.sourceMappingFileName) : ( path.basename(file.path) + '.map' );
 
-            var pos = src.search(/\/[\/\*][#@]\s+sourceMappingURL=data:application\/json;base64,/i)
+            var pos = src.search(/\/[\/\*][#@]\s+sourceMappingURL=data:application\/json;(?:charset:utf-8;)?base64,/i)
 
             if (~pos) {
                 try {


### PR DESCRIPTION
Sourcemap comment style is different between browserify versions.
This commit changes to support both styles in a hacky way.
- Browserify 9.0.8: `//# sourceMappingURL=data:application/json;base64,...`
- Browserify 10.2.1: `//# sourceMappingURL=data:application/json;charset:utf-8;base64,...`
