### PR TITLE
Fixed map sources paths in windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ function extract(opts){
                     var basedir = opts.basedir || file.cwd || process.cwd();
 
                     for (var i = sMap.sources.length; i--;) {
-                        sMap.sources[i] = path.relative( basedir, sMap.sources[i] );
+                        var normalizedPath = path.relative( basedir, sMap.sources[i] );
+                        normalizedPath = normalizedPath.split(path.sep).join('/');
+                        sMap.sources[i] = normalizedPath;
                     }
                 }
             }

--- a/test/main.js
+++ b/test/main.js
@@ -44,7 +44,7 @@ it('should javascript correct processed without any params', function (cb) {
             var src = file.contents.toString('utf8');
             assert(/\/\/# sourceMappingURL=bundle\.js\.map/.test(src), 'javascript source must constaint correct source map link');
         } else {
-            assert.equal(file.path, 'src/bundle.js.map', 'correct source map filename');
+            assert.equal(file.path, path.join('src', 'bundle.js.map'), 'correct source map filename');
         }
     });
 
@@ -84,7 +84,7 @@ it('should css correct processed without any params', function (cb) {
             var src = file.contents.toString('utf8');
             assert(/\/\*# sourceMappingURL=icons\.css\.map \*\//.test(src), 'css source must constaint correct source map link');
         } else {
-            assert.equal(file.path, 'css/icons.css.map', 'correct source map filename');
+            assert.equal(file.path, path.join('css', 'icons.css.map'), 'correct source map filename');
         }
     });
 
@@ -116,7 +116,7 @@ it('should javascript correct processed with params', function (cb) {
             var src = file.contents.toString('utf8');
             assert(/\/\/# sourceMappingURL=http:\/\/static\.exsample\.com\/js\/souceMap\.js\.map/.test(src), 'javascript source must constaint correct source map link');
         } else {
-            assert.equal(file.path, 'src/souceMap.js.map', 'correct source map filename');
+            assert.equal(file.path, path.join('src', 'souceMap.js.map'), 'correct source map filename');
         }
     });
 
@@ -142,6 +142,27 @@ it('should missing-map event emit and postextract event provides empty string', 
     stream.on('end', function(){
         assert.equal(mapFileInStream, false, 'mapFileInStream must be equal boolean false');
         assert.equal(sourceMap, '', 'sourceMap must be equal empty string');
+        cb();
+    });
+
+    stream.end();
+});
+
+it('should normalize map sources', function (cb) {
+    mapFileInStream = false;
+    sourceMap = undefined;
+    sourceMapData = undefined;
+    var stream =initStream(mapedBundleSrc);
+
+    stream.on('data', function(file){
+        commonDataCB(file);
+    });
+
+    stream.on('end', function(){
+        sourceMap.sources.forEach(function(normalizedPath){
+            var expectedPath = normalizedPath.split('\\').join('/');
+            assert.equal(normalizedPath, expectedPath, 'sources paths must be normalized');
+        })
         cb();
     });
 


### PR DESCRIPTION
Hi.

Running this package in Windows OS was causing a malformed sourcemap.
When calling `JSON.stringify` the slashes (`\`) are being escaped, causing something like this:

![pullsourcemaps](https://cloud.githubusercontent.com/assets/3719730/10767875/b30d3770-7cde-11e5-895b-22c77c604fcf.png)
