### PR TITLE
Fix charset regexp to match RFC

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function extract(opts){
             var src = file.contents.toString('utf8');
             var sMapFileName = opts.sourceMappingFileName ? path.basename(opts.sourceMappingFileName) : ( path.basename(file.path) + '.map' );
 
-            var pos = src.search(/\/[\/\*][#@]\s+sourceMappingURL=data:application\/json;(?:charset:utf-8;)?base64,/i);
+            var pos = src.search(/\/[\/\*][#@]\s+sourceMappingURL=data:application\/json;(?:charset=utf-8;)?base64,/i);
 
             if (~pos) {
                 try {


### PR DESCRIPTION
https://tools.ietf.org/html/rfc2397 states that the charset may be specified as e.g. ";charset=utf-8"